### PR TITLE
added interpolation on getString

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -30,24 +30,27 @@ angular.module('gettext').factory('gettextCatalog', ['gettextPlurals', '$interpo
             }
         },
 
-        getStringForm: function (string, n) {
+        getStringForm: function (string, n, dataObject) {
             var stringTable = this.strings[this.currentLanguage] || {};
             var plurals = stringTable[string] || [];
             return plurals[n];
         },
 
         getString: function (string, dataObject) {
-            var text = this.getStringForm(string, 0) || prefixDebug(string);
+            var text = this.getStringForm(string, 0, dataObject) || prefixDebug(string);
             if (angular.isObject(dataObject)) {
                 return $interpolate(text)(dataObject);
-            } else {
-                return text;
             }
+            return text;
         },
 
-        getPlural: function (n, string, stringPlural) {
+        getPlural: function (n, string, stringPlural, dataObject) {
             var form = gettextPlurals(this.currentLanguage, n);
-            return this.getStringForm(string, form) || prefixDebug((n === 1 ? string : stringPlural));
+            var text = this.getStringForm(string, form, dataObject) || prefixDebug((n === 1 ? string : stringPlural));
+            if (angular.isObject(dataObject)) {
+                return $interpolate(text)(dataObject);
+            }
+            return text;
         }
     };
 

--- a/test/unit/catalog.coffee
+++ b/test/unit/catalog.coffee
@@ -87,6 +87,31 @@ describe 'Catalog', ->
         catalog.currentLanguage = 'nl'
         assert.equal(catalog.getPlural(2, 'Bird', 'Birds'), '[MISSING]: Birds')
 
+    it 'Should return singular for singular strings with interpolation', ->
+        catalog.currentLanguage = 'nl'
+        catalog.setStrings('nl', {
+            '{{ count }} bird': [ '{{ count }} vogel', '{{ count }} vogels' ]
+        })
+        assert.equal(catalog.getPlural(1, '{{ count }} bird', '{{ count }} birds', { count: 1 }), '1 vogel')
+
+    it 'Should return plural for plural strings with interpolation', ->
+        catalog.currentLanguage = 'nl'
+        catalog.setStrings('nl', {
+            '{{ count }} bird': [ '{{ count }} vogel', '{{ count }} vogels' ]
+        })
+        assert.equal(catalog.getPlural(2, '{{ count }} bird', '{{ count }} birds', { count: 2 }), '2 vogels')
+
+    it 'Should add prefix for untranslated plural strings when in debug (single)', ->
+        catalog.debug = true
+        catalog.currentLanguage = 'nl'
+        assert.equal(catalog.getPlural(1, '{{ count }} bird', '{{ count }} birds', { count: 1 }), '[MISSING]: 1 bird')
+
+    it 'Should add prefix for untranslated plural strings when in debug', ->
+        catalog.debug = true
+        catalog.currentLanguage = 'nl'
+        assert.equal(catalog.getPlural(2, '{{ count }} bird', '{{ count }} birds', { count: 2 }), '[MISSING]: 2 birds')
+
+
 
 
 


### PR DESCRIPTION
Hello

I added a new feature: use of interpolation in translated string in Javascript files.Example:
var myString = gettextCatalog.getString('Hello {{ name }}!', {name: 'World'});

myString will be 'Hello World!'

See https://github.com/rubenv/grunt-angular-gettext/pull/24 for grunt-angular-gettext counterpart
