### PR TITLE
The preferred/default language is not always English

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -2,7 +2,7 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals) {
     var catalog;
 
     var prefixDebug = function (string) {
-        if (catalog.debug && catalog.currentLanguage !== 'en') {
+        if (catalog.debug && catalog.currentLanguage !== catalog.baseLanguage) {
             return "[MISSING]: " + string;
         } else {
             return string;
@@ -12,6 +12,7 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals) {
     catalog = {
         debug: false,
         strings: {},
+        baseLanguage: 'en',
         currentLanguage: 'en',
 
         setStrings: function (language, strings) {

--- a/test/unit/catalog.coffee
+++ b/test/unit/catalog.coffee
@@ -40,6 +40,11 @@ describe 'Catalog', ->
         catalog.currentLanguage = 'en'
         assert.equal(catalog.getString('Hello'), 'Hello')
 
+    it 'Should not add prefix for untranslated strings in preferred language', ->
+        catalog.debug = true
+        catalog.currentLanguage = catalog.baseLanguage
+        assert.equal(catalog.getString('Hello'), 'Hello')
+
     it 'Should return singular for unknown singular strings', ->
         assert.equal(catalog.getPlural(1, 'Bird', 'Birds'), 'Bird')
 


### PR DESCRIPTION
Introduce a new variable to configure the preferred/default language (default value 'en').

One might code an application in French and then translate it to English. Then you don't want the "[MISSING]" thing everywhere in debug mode if the preferred language (French in this case) is the current one.

Note: I have a doubt how to name this variable, `preferredLanguage` or `defaultLanguage`?
angular-translate uses [`preferredLanguage`](http://pascalprecht.github.io/angular-translate/docs/en/#/api/pascalprecht.translate.$translate#fallbackLanguage).
