### PR TITLE
Make gettext() work as expected

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,7 @@
 angular.module('gettext', []);
 
-angular.module('gettext').constant('gettext', function (str) {
-    /*
-     * Does nothing, simply returns the input string.
-     *
-     * This function serves as a marker for `grunt-angular-gettext` to know that
-     * this string should be extracted for translations.
-     */
-    return str;
-});
+angular.module('gettext').factory('gettext', ['gettextCatalog', function (gettextCatalog) {
+    return function (str) {
+        return gettextCatalog.getString(str);
+    };
+}]);


### PR DESCRIPTION
Not having gettext() return a translated string is very inconsistent with implementations in most other languages. This PR makes the function work as expected.
