### PR TITLE
Add Textdomain Support

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -49,8 +49,8 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, $h
         },
 
         getStringForm: function (string, n, domain) {
-            var stringTable = this.strings[this.currentLanguage] || {};
-            var plurals = stringTable[string] && stringTable[string][domain] || [];
+            var stringTable = this.strings[this.currentLanguage] && this.strings[this.currentLanguage][domain] || {};
+            var plurals = stringTable[string] || [];
             return plurals[n];
         },
 

--- a/src/catalog.js
+++ b/src/catalog.js
@@ -25,7 +25,13 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, $h
             broadcastUpdated();
         },
 
-        setStrings: function (language, strings) {
+        setStrings: function (language, strings, domain) {
+            domain = domain || 'default';
+
+            if (!this.strings[language]) {
+                this.strings[language] = {};
+            }
+
             if (!this.strings[language]) {
                 this.strings[language] = {};
             }

--- a/src/catalog.js
+++ b/src/catalog.js
@@ -32,47 +32,49 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, $h
                 this.strings[language] = {};
             }
 
-            if (!this.strings[language]) {
-                this.strings[language] = {};
+            if (!this.strings[language][domain]) {
+                this.strings[language][domain] = {};
             }
 
             for (var key in strings) {
                 var val = strings[key];
                 if (typeof val === 'string') {
-                    this.strings[language][key] = [val];
+                    this.strings[language][domain][key] = [val];
                 } else {
-                    this.strings[language][key] = val;
+                    this.strings[language][domain][key] = val;
                 }
             }
 
             broadcastUpdated();
         },
 
-        getStringForm: function (string, n) {
+        getStringForm: function (string, n, domain) {
             var stringTable = this.strings[this.currentLanguage] || {};
-            var plurals = stringTable[string] || [];
+            var plurals = stringTable[string][domain] || [];
             return plurals[n];
         },
 
-        getString: function (string, context) {
-            string = this.getStringForm(string, 0) || prefixDebug(string);
+        getString: function (string, context, domain) {
+            domain = domain || 'default';
+            string = this.getStringForm(string, 0, domain) || prefixDebug(string);
             return context ? $interpolate(string)(context) : string;
         },
 
-        getPlural: function (n, string, stringPlural, context) {
+        getPlural: function (n, string, stringPlural, context, domain) {
             var form = gettextPlurals(this.currentLanguage, n);
-            string = this.getStringForm(string, form) || prefixDebug(n === 1 ? string : stringPlural);
+            domain = domain || 'default';
+            string = this.getStringForm(string, form, domain) || prefixDebug(n === 1 ? string : stringPlural);
             return context ? $interpolate(string)(context) : string;
         },
 
-        loadRemote: function (url) {
+        loadRemote: function (url, domain) {
             return $http({
                 method: 'GET',
                 url: url,
                 cache: catalog.cache
             }).success(function (data) {
                 for (var lang in data) {
-                    catalog.setStrings(lang, data[lang]);
+                    catalog.setStrings(lang, data[lang], domain);
                 }
             });
         }

--- a/src/catalog.js
+++ b/src/catalog.js
@@ -50,7 +50,7 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, $h
 
         getStringForm: function (string, n, domain) {
             var stringTable = this.strings[this.currentLanguage] || {};
-            var plurals = stringTable[string][domain] || [];
+            var plurals = stringTable[string] && stringTable[string][domain] || [];
             return plurals[n];
         },
 

--- a/src/directive.js
+++ b/src/directive.js
@@ -41,9 +41,9 @@ angular.module('gettext').directive('translate', function (gettextCatalog, $pars
                         if (translatePlural) {
                             scope = pluralScope || (pluralScope = scope.$new());
                             scope.$count = countFn(scope);
-                            translated = gettextCatalog.getPlural(scope.$count, msgid, translatePlural, translateDomain);
+                            translated = gettextCatalog.getPlural(scope.$count, msgid, translatePlural, null, translateDomain);
                         } else {
-                            translated = gettextCatalog.getString(msgid, translateDomain);
+                            translated = gettextCatalog.getString(msgid, null, translateDomain);
                         }
 
                         // Swap in the translation

--- a/src/directive.js
+++ b/src/directive.js
@@ -28,6 +28,7 @@ angular.module('gettext').directive('translate', function (gettextCatalog, $pars
 
             var msgid = trim(element.html());
             var translatePlural = attrs.translatePlural;
+            var translateDomain = attrs.translate || attrs.translateDomain;
 
             return {
                 post: function (scope, element, attrs) {
@@ -40,9 +41,9 @@ angular.module('gettext').directive('translate', function (gettextCatalog, $pars
                         if (translatePlural) {
                             scope = pluralScope || (pluralScope = scope.$new());
                             scope.$count = countFn(scope);
-                            translated = gettextCatalog.getPlural(scope.$count, msgid, translatePlural);
+                            translated = gettextCatalog.getPlural(scope.$count, msgid, translatePlural, translateDomain);
                         } else {
-                            translated = gettextCatalog.getString(msgid);
+                            translated = gettextCatalog.getString(msgid, translateDomain);
                         }
 
                         // Swap in the translation

--- a/test/unit/catalog.js
+++ b/test/unit/catalog.js
@@ -11,7 +11,7 @@ describe("Catalog", function () {
         var strings = { Hello: "Hallo" };
         assert.deepEqual(catalog.strings, {});
         catalog.setStrings("nl", strings);
-        assert.deepEqual(catalog.strings.nl.default.Hello[0], "Hallo");
+        assert.deepEqual(catalog.strings.nl["default"].Hello[0], "Hallo");
     });
 
     it("Can retrieve strings", function () {

--- a/test/unit/catalog.js
+++ b/test/unit/catalog.js
@@ -11,7 +11,7 @@ describe("Catalog", function () {
         var strings = { Hello: "Hallo" };
         assert.deepEqual(catalog.strings, {});
         catalog.setStrings("nl", strings);
-        assert.deepEqual(catalog.strings.nl.Hello[0], "Hallo");
+        assert.deepEqual(catalog.strings.nl.default.Hello[0], "Hallo");
     });
 
     it("Can retrieve strings", function () {
@@ -19,6 +19,20 @@ describe("Catalog", function () {
         catalog.setStrings("nl", strings);
         catalog.currentLanguage = "nl";
         assert.equal(catalog.getString("Hello"), "Hallo");
+    });
+
+    it("Can set strings on a textdomain", function () {
+        var strings = { Hello: "Hallo" };
+        assert.deepEqual(catalog.strings, {});
+        catalog.setStrings("nl", strings, "testDomain");
+        assert.deepEqual(catalog.strings.nl.testDomain.Hello[0], "Hallo");
+    });
+
+    it("Can retrieve strings on a textdomain", function () {
+        var strings = { Hello: "Hallo" };
+        catalog.setStrings("nl", strings, "testDomain");
+        catalog.currentLanguage = "nl";
+        assert.equal(catalog.getString("Hello", null, "testDomain"), "Hallo");
     });
 
     it("Should return original for unknown strings", function () {

--- a/test/unit/directive.js
+++ b/test/unit/directive.js
@@ -40,12 +40,46 @@ describe("Directive", function () {
         assert.equal(el.text(), "Hallo Ruben!");
     });
 
+    it("Should translate known strings on specified textdomains", function () {
+        catalog.currentLanguage = "nl";
+        catalog.setStrings("nl", {
+            Welcome: "Welkom"
+        }, "testDomain");
+
+        var el = $compile("<div><h1 translate=\"testDomain\">Welcome</h1></div>")($rootScope);
+        $rootScope.$digest();
+        assert.equal(el.text(), "Welkom");
+    });
+
+    it("Should translate known strings on specified textdomains using alternate syntax", function () {
+        catalog.currentLanguage = "nl";
+        catalog.setStrings("nl", {
+            Welcome: "Welkom"
+        }, "testDomain");
+
+        var el = $compile("<div><h1 translate translate-domain=\"testDomain\">Welcome</h1></div>")($rootScope);
+        $rootScope.$digest();
+        assert.equal(el.text(), "Welkom");
+    });
+
     it("Can provide plural value and string, should translate", function () {
         $rootScope.count = 3;
         catalog.currentLanguage = "nl";
         var el = $compile("<div><div translate translate-n=\"count\" translate-plural=\"{{count}} boats\">One boat</div></div>")($rootScope);
         $rootScope.$digest();
         assert.equal(el.text(), "3 boten");
+    });
+
+    it("Can provide plural value, string, and textdomain, should translate", function () {
+        $rootScope.count = 3;
+        catalog.currentLanguage = "nl";
+        catalog.setStrings("nl", {
+            "One car": ["Een auto", "{{count}} autos"]
+        }, "testDomain");
+
+        var el = $compile("<div><div translate=\"testDomain\" translate-n=\"count\" translate-plural=\"{{count}} cars\">One car</div></div>")($rootScope);
+        $rootScope.$digest();
+        assert.equal(el.text(), "3 autos");
     });
 
     it("Can provide plural value and string, should translate even for unknown languages", function () {

--- a/test/unit/loading.js
+++ b/test/unit/loading.js
@@ -19,7 +19,7 @@ describe("String loading", function () {
         $httpBackend.flush();
     });
 
-    it("Will set the loaded strings", function () {
+    it("Will set the loaded strings in the default textdomain", function () {
         catalog.loadRemote("/strings/nl.json");
         $httpBackend.expectGET("/strings/nl.json").respond(200, {
             nl: {
@@ -27,7 +27,18 @@ describe("String loading", function () {
             }
         });
         $httpBackend.flush();
-        assert.notEqual(void 0, catalog.strings.nl);
+        assert.notEqual(void 0, catalog.strings.nl.default);
+    });
+
+    it("Will set the loaded strings in a specified textdomain", function () {
+        catalog.loadRemote("/strings/nl.json", "testDomain");
+        $httpBackend.expectGET("/strings/nl.json").respond(200, {
+            nl: {
+                Hello: "Hallo"
+            }
+        });
+        $httpBackend.flush();
+        assert.notEqual(void 0, catalog.strings.nl.testDomain);
     });
 
     it("Gracefully handles failure", function () {

--- a/test/unit/loading.js
+++ b/test/unit/loading.js
@@ -27,7 +27,7 @@ describe("String loading", function () {
             }
         });
         $httpBackend.flush();
-        assert.notEqual(void 0, catalog.strings.nl.default);
+        assert.notEqual(void 0, catalog.strings.nl["default"]);
     });
 
     it("Will set the loaded strings in a specified textdomain", function () {


### PR DESCRIPTION
Using either syntax:
```
<span translate="testDomain">Hello</span>
<span translate translate-domain="testDomain">Hello</span>
```

Works with Contexts/Interpolation and Plurals
Tests are included