### PR TITLE
commonjs package manager support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,13 @@ module.exports = function (grunt) {
         },
 
         concat: {
+            options: {
+                banner: "/* commonjs package manager support (eg componentjs) */\n" +
+                    "if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.exports === exports){\n" +
+                    "    module.exports = 'gettext';\n" +
+                    "}\n\n"
+
+            },
             dist: {
                 files: {
                     "dist/angular-gettext.js": ["src/index.js", "src/*.js"]


### PR DESCRIPTION
Added support for allowing use of commonjs package manager or es6 modules.
Example:

    import gettext from 'angular-gettext';
    angular.module('my-module', [gettext]);

This is very useful for people using module bundlers such as browserify or webpack.