### PR TITLE
Add support for fallbackLanguage

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -38,6 +38,7 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, $h
         strings: {},
         baseLanguage: 'en',
         currentLanguage: 'en',
+        fallbackLanguage: undefined,
         cache: $cacheFactory('strings'),
 
         setCurrentLanguage: function (lang) {
@@ -47,6 +48,15 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, $h
 
         getCurrentLanguage: function () {
             return this.currentLanguage;
+        },
+
+        setFallbackLanguage: function (lang) {
+            this.fallbackLanguage = lang;
+            broadcastUpdated();
+        },
+
+        getFallbackLanguage: function () {
+            return this.fallbackLanguage;
         },
 
         setStrings: function (language, strings) {
@@ -80,11 +90,19 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, $h
             broadcastUpdated();
         },
 
-        getStringForm: function (string, n, context) {
-            var stringTable = this.strings[this.currentLanguage] || {};
+        getStringFormLanguage: function (string, n, context, lang) {
+            var stringTable = this.strings[lang] || {};
             var contexts = stringTable[string] || {};
             var plurals = contexts[context || noContext] || [];
             return plurals[n];
+        },
+
+        getStringForm: function (string, n, context) {
+            var result = this.getStringFormLanguage(string, n, context, this.currentLanguage);
+            if (!result && this.fallbackLanguage) {
+                result = this.getStringFormLanguage(string, n, context, this.fallbackLanguage);
+            }
+            return result;
         },
 
         getString: function (string, scope, context) {


### PR DESCRIPTION
This is useful for situations where ID-based translations
are used and where a fallback to another language is desirable.

Example:

* Source strings are ID-based, e.g. `LABEL_SOMETHING`
* Strings are translated to English: e.g. "Something"
* Strings are translated to German, but missing some translations

Setting:

```
gettextContext.setCurrentLanguage('de');
gettextContext.setFallbackLanguage('en');
```

Should then return the English string if the German string is not
available (e.g. `LABEL_SOMETHING` returns "Something" in German).