### PR TITLE
Fix bug TypeError: Cannot read property 'querySelectorAll' of undefined when use directive for a leaf node

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -62,7 +62,10 @@ angular.module('gettext').directive('translate', function (gettextCatalog, $pars
                         if (oldContents.length === 0){
                             return;
                         }
-
+                        
+                        if (!oldContents.html())
+                            $compile(oldContents)(scope);
+                        
                         // Avoid redundant swaps
                         if (translated === trim(oldContents.html())){
                             // Take care of unlinked content


### PR DESCRIPTION
e.g: 
element =  [<a translate>​Cancel​</a>​]
oldContents = ["Cancel"]

$animate.leave(oldContents); will cause error and then translated element will have both untranslated string and translated string.