### PR TITLE
Add a callback to loadRemote()

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -103,7 +103,7 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, $h
             return addTranslatedMarkers(string);
         },
 
-        loadRemote: function (url) {
+        loadRemote: function (url, cb) {
             return $http({
                 method: 'GET',
                 url: url,
@@ -112,6 +112,8 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, $h
                 for (var lang in data) {
                     catalog.setStrings(lang, data[lang]);
                 }
+                if (typeof cb === 'function')
+                    cb();
             });
         }
     };


### PR DESCRIPTION
If you want to show a loading indicator while loading the json or to change the current language only after the json was successfully loaded you need a callback function. A error callback function could be added too.