### PR TITLE
Check that loadRemote returns a Javascript object, not html

### DIFF
--- a/dist/angular-gettext.js
+++ b/dist/angular-gettext.js
@@ -10,7 +10,7 @@ angular.module('gettext').constant('gettext', function (str) {
     return str;
 });
 
-angular.module('gettext').factory('gettextCatalog', ["gettextPlurals", "$http", "$cacheFactory", "$interpolate", "$rootScope", function (gettextPlurals, $http, $cacheFactory, $interpolate, $rootScope) {
+angular.module('gettext').factory('gettextCatalog', ["gettextPlurals", "$q", "$http", "$cacheFactory", "$interpolate", "$rootScope", function (gettextPlurals, $q, $http, $cacheFactory, $interpolate, $rootScope) {
     var catalog;
     var noContext = '$$noContext';
 
@@ -120,7 +120,12 @@ angular.module('gettext').factory('gettextCatalog', ["gettextPlurals", "$http", 
                 method: 'GET',
                 url: url,
                 cache: catalog.cache
-            }).success(function (data) {
+            }).success(function(data) {
+                // ensure the response is a Javascript object
+                if(!data || typeof data !== 'object'){
+                    return $q.reject(new Error("Response must contain valid JSON"));
+                }
+
                 for (var lang in data) {
                     catalog.setStrings(lang, data[lang]);
                 }


### PR DESCRIPTION
Problem: On our integration and production environments, our nginx config file redirects a user to index.html - our landing page - when a file is not found. This redirection returns a 200 http code. The loadRemote method in angular-gettext only checks for a successful http response, so it tries to parse our html as if it is JSON. This causes our app to crash when run in Firefox or Safari.

Solution: This proposed change checks that the successful response from loadRemote is returning a Javascript object (JSON), rather than html, to prevent browser crashes.