### PR TITLE
add Meteor package description

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -137,7 +137,8 @@ module.exports = function (grunt) {
         bump: {
             options: {
                 files: ["package.json", "bower.json", "package.js"],
-                commitFiles: ["-a"]
+                commitFiles: ["-a"],
+                pushTo: "origin"
             }
         }
     });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,9 +136,8 @@ module.exports = function (grunt) {
 
         bump: {
             options: {
-                files: ["package.json", "bower.json"],
-                commitFiles: ["-a"],
-                pushTo: "origin"
+                files: ["package.json", "bower.json", "package.js"],
+                commitFiles: ["-a"]
             }
         }
     });

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gettext",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "main": "dist/angular-gettext.js",
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gettext",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "main": "dist/angular-gettext.js",
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gettext",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "dist/angular-gettext.js",
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gettext",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "dist/angular-gettext.js",
   "ignore": [
     "**/.*",

--- a/package.js
+++ b/package.js
@@ -1,5 +1,9 @@
 var packageName = 'rubenv:angular-gettext';
 
+var options = {
+  "version": "2.1.1",
+  "where": "client"
+};
 var where = 'client';
 var version = '2.1.0';
 

--- a/package.js
+++ b/package.js
@@ -1,0 +1,19 @@
+var packageName = 'rubenv:angular-gettext';
+
+var where = 'client';
+var version = '2.1.0';
+
+// meta data
+Package.describe({
+  name: packageName,
+  version: version,
+  summary: 'Gettext support for Angular.js',
+  git: 'git://github.com/rubenv/angular-gettext.git',
+  documentation: 'README.md'
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom('METEOR@0.9.0', 'METEOR@1.0');
+  api.use('angular:angular@1.2.0', where);
+  api.addFiles('dist/angular-gettext.js', where);
+});

--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 var options = {
-  "version": "2.1.3",
+  "version": "2.1.0",
   "where": "client",
   "packageName": "rubenv:angular-gettext"
 };

--- a/package.js
+++ b/package.js
@@ -1,16 +1,13 @@
-var packageName = 'rubenv:angular-gettext';
-
 var options = {
-  "version": "2.1.1",
-  "where": "client"
+  "version": "2.1.2",
+  "where": "client",
+  "packageName": "rubenv:angular-gettext"
 };
-var where = 'client';
-var version = '2.1.0';
 
 // meta data
 Package.describe({
-  name: packageName,
-  version: version,
+  name: options.packageName,
+  version: options.version,
   summary: 'Gettext support for Angular.js',
   git: 'git://github.com/rubenv/angular-gettext.git',
   documentation: 'README.md'
@@ -18,6 +15,6 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom('METEOR@0.9.0', 'METEOR@1.0');
-  api.use('angular:angular@1.2.0', where);
-  api.addFiles('dist/angular-gettext.js', where);
+  api.use('angular:angular@1.2.0', options.where);
+  api.addFiles('dist/angular-gettext.js', options.where);
 });

--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 var options = {
-  "version": "2.1.2",
+  "version": "2.1.3",
   "where": "client",
   "packageName": "rubenv:angular-gettext"
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gettext",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Gettext support for Angular.js",
   "main": "dist/angular-gettext.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gettext",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Gettext support for Angular.js",
   "main": "dist/angular-gettext.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gettext",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Gettext support for Angular.js",
   "main": "dist/angular-gettext.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gettext",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Gettext support for Angular.js",
   "main": "dist/angular-gettext.js",
   "directories": {


### PR DESCRIPTION
I've added `packages.js` to make this module available for Meteor apps.
In order to publish it as `rubenv:angular-gettext` I had to create a Meteor organization called "rubenv". Please contact me if you want to be added to that organization. I'll remove myself then.
