### PR TITLE
Html element attribute reordering

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -14,13 +14,6 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, ge
     var catalog;
     var noContext = '$$noContext';
 
-    // IE8 returns UPPER CASE tags, even though the source is lower case.
-    // This can causes the (key) string in the DOM to have a different case to
-    // the string in the `po` files.
-    // IE9, IE10 and IE11 reorders the attributes of tags.
-    var test = '<span id="test" title="test" class="tested">test</span>';
-    var isHTMLModified = (angular.element('<span>' + test + '</span>').html() !== test);
-
     var prefixDebug = function (string) {
         if (catalog.debug && catalog.currentLanguage !== catalog.baseLanguage) {
             return catalog.debugPrefix + string;
@@ -168,7 +161,13 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, ge
             for (var key in strings) {
                 var val = strings[key];
 
-                if (isHTMLModified) {
+                // test for the presence of HTML tags in the key, as indicated
+                // by `<`
+                if (key.indexOf('<') !== -1) {
+                    // IE8 returns UPPER CASE tags, even though the source is lower case.
+                    // This can causes the (key) string in the DOM to have a different case to
+                    // the string in the `po` files.
+                    // IE9, IE10 and IE11 and recent FF verions reorder the attributes of tags.
                     // Use the DOM engine to render any HTML in the key (#131).
                     key = angular.element('<span>' + key + '</span>').html();
                 }

--- a/test/unit/directive.js
+++ b/test/unit/directive.js
@@ -13,7 +13,8 @@ describe("Directive", function () {
             Hello: "Hallo",
             "Hello {{name}}!": "Hallo {{name}}!",
             "One boat": ["Een boot", "{{count}} boten"],
-            Archive: { verb: "Archiveren", noun: "Archief" }
+            Archive: { verb: "Archiveren", noun: "Archief" },
+            '<input type="submit" value="Hello">': '<input type="submit" value="Hallo">'
         });
         catalog.setStrings("af", {
             "This link: <a class=\"extra-class\" ng-href=\"{{url}}\">{{url}}</a> will have the 'ng-binding' class attached before the translate directive can capture it.": "Die skakel: <a ng-href=\"{{url}}\">{{url}}</a> sal die 'ng-binding' klass aangevoeg hê voor die translate directive dit kan vasvat."
@@ -223,5 +224,12 @@ describe("Directive", function () {
         var el = $compile("<translate>Hello</translate>")($rootScope);
         $rootScope.$digest();
         assert.equal(el.text(), "Hallo");
+    });
+
+    it("Should work when containing an <input> tag to be translated", function () {
+        catalog.currentLanguage = "nl";
+        var el = $compile('<translate><input type="submit" value="Hello"></translate>')($rootScope);
+        $rootScope.$digest();
+        assert.notStrictEqual(el.html().indexOf("Hallo"), -1);
     });
 });


### PR DESCRIPTION
Hi!

I might be mistaken, but when I try to translate

``` html
<input type="submit" value="Hello">
```

to 

``` html
<input type="submit" value="Hallo">
```

it seems that Firefox does what IE did in #131, namely reorder the attributes when loading the translations. I added a test that fails for me (Firefox 44.0, Ubuntu 15.10) and a fix for the problem, but I’m not sure that this is the Right Way To Do It™ (I assume the previous `isHTMLModified` test, as opposed to always doing the DOM rendering, was for performance reasons, but I might be wrong about that).
