### PR TITLE
Use PhantomJS 2 for automated tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
+sudo: false
 before_install:
   - npm install -g grunt-cli bower
   - bower install

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,17 +96,17 @@ module.exports = function (grunt) {
         karma: {
             unit: {
                 configFile: "test/configs/unit.conf.js",
-                browsers: ["PhantomJS"],
+                browsers: ["PhantomJS2"],
                 background: true
             },
             unit_nojquery: {
                 configFile: "test/configs/unit-nojquery.conf.js",
-                browsers: ["PhantomJS"],
+                browsers: ["PhantomJS2"],
                 background: true
             },
             unitci: {
                 configFile: "test/configs/unit.conf.js",
-                browsers: ["Firefox", "PhantomJS"],
+                browsers: ["Firefox", "PhantomJS2"],
                 singleRun: true,
                 reporters: ["dots", "junit"],
                 junitReporter: {
@@ -115,7 +115,7 @@ module.exports = function (grunt) {
             },
             unitci_nojquery: {
                 configFile: "test/configs/unit-nojquery.conf.js",
-                browsers: ["Firefox", "PhantomJS"],
+                browsers: ["Firefox", "PhantomJS2"],
                 singleRun: true,
                 reporters: ["dots", "junit"],
                 junitReporter: {
@@ -124,12 +124,12 @@ module.exports = function (grunt) {
             },
             e2e: {
                 configFile: "test/configs/e2e.conf.js",
-                browsers: ["PhantomJS"],
+                browsers: ["PhantomJS2"],
                 background: true
             },
             e2eci: {
                 configFile: "test/configs/e2e.conf.js",
-                browsers: ["Firefox", "PhantomJS"],
+                browsers: ["Firefox", "PhantomJS2"],
                 singleRun: true,
                 reporters: ["dots", "junit"],
                 junitReporter: {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "karma-junit-reporter": "~0.2.2",
     "karma-mocha": "~0.1.0",
     "karma-ng-scenario": "~0.1.0",
-    "karma-phantomjs-launcher": "^0.1.4"
+    "karma-phantomjs2-launcher": "^0.5.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes the current build, which is broken on angular 1.5.0 due to angular/angular.js#13794.