### PR TITLE
fix: arabic (ar) default plural for 1 maps correctly

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -183,7 +183,10 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, ge
                 // Expand single strings for each context.
                 for (var context in val) {
                     var str = val[context];
-                    val[context] = angular.isArray(str) ? str : [str];
+                    if (!angular.isArray(str)) {
+                        val[context] = [];
+                        val[context][gettextPlurals(language, 1)] = str;
+                    }
                 }
                 this.strings[language][key] = val;
             }

--- a/src/catalog.js
+++ b/src/catalog.js
@@ -165,6 +165,7 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, ge
                 this.strings[language] = {};
             }
 
+            var defaultPlural = gettextPlurals(language, 1);
             for (var key in strings) {
                 var val = strings[key];
 
@@ -185,7 +186,7 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, ge
                     var str = val[context];
                     if (!angular.isArray(str)) {
                         val[context] = [];
-                        val[context][gettextPlurals(language, 1)] = str;
+                        val[context][defaultPlural] = str;
                     }
                 }
                 this.strings[language][key] = val;

--- a/test/unit/catalog.js
+++ b/test/unit/catalog.js
@@ -21,6 +21,13 @@ describe("Catalog", function () {
         assert.equal(catalog.getString("Hello"), "Hallo");
     });
 
+    it("Can set and retrieve strings when default plural is not zero", function () {
+        var strings = { Hello: "Hallo" };
+        catalog.setStrings("ar", strings);
+        catalog.setCurrentLanguage("ar");
+        assert.equal(catalog.getString("Hello"), "Hallo");
+    });
+
     it("Should return original for unknown strings", function () {
         var strings = { Hello: "Hallo" };
         catalog.setStrings("nl", strings);


### PR DESCRIPTION
The setStrings function should use the same default plural form as getString -- which uses the result of passing '1' to gettextPlurals.

Fixes #260 