### PR TITLE
Fix typo

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -8,7 +8,7 @@
  * @requires https://docs.angularjs.org/api/ng/service/$cacheFactory $cacheFactory
  * @requires https://docs.angularjs.org/api/ng/service/$interpolate $interpolate
  * @requires https://docs.angularjs.org/api/ng/service/$rootScope $rootScope
- * @description Provides set of method to translate stings
+ * @description Provides set of method to translate strings
  */
 angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, gettextFallbackLanguage, $http, $cacheFactory, $interpolate, $rootScope) {
     var catalog;
@@ -206,7 +206,7 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, ge
          * @protected
          * @param {String} language language name
          * @param {String} string translation key
-         * @param {Number=} n number to build sting form for
+         * @param {Number=} n number to build string form for
          * @param {String=} context translation key context, e.g. {@link doc:context Verb, Noun}
          * @returns {String|Null} translated or annotated string or null if language is not set
          * @description Translate a string with the given language, count and context.
@@ -253,7 +253,7 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, ge
          * @ngdoc method
          * @name gettextCatalog#getPlural
          * @public
-         * @param {Number} n number to build sting form for
+         * @param {Number} n number to build string form for
          * @param {String} string translation key
          * @param {String} stringPlural plural translation key
          * @param {$rootScope.Scope=} scope scope to do interpolation against


### PR DESCRIPTION
In addition, the documentation of the website is outdated.
See https://angular-gettext.rocketeer.be/dev-guide/api/angular-gettext/ where getString and getPlural are missing the `scope` parameter.

Context: https://github.com/camptocamp/ngeo/pull/3034.