### PR TITLE
Corrected overcorrections which caused ampersands to be html-encoded

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -177,6 +177,8 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, ge
             return this.currentLanguage;
         },
 
+        rollBackOvercorrections: rollBackOvercorrections,
+
         /**
          * @ngdoc method
          * @name gettextCatalog#setStrings
@@ -195,14 +197,10 @@ angular.module('gettext').factory('gettextCatalog', function (gettextPlurals, ge
                 var val = strings[key];
 
                 if (isHTMLModified) {
-
-                    //keep a copy of the original key for comparison later
+                    //save the original before we change it
                     var originalKey = key;
-
                     // Use the DOM engine to render any HTML in the key (#131).
                     key = angular.element('<span>' + key + '</span>').html();
-
-                    //now that we have a "corrected" key, rollback the overcorrections for & character
                     key = rollBackOvercorrections(originalKey, key);
                 }
 

--- a/src/directive.js
+++ b/src/directive.js
@@ -97,6 +97,7 @@ angular.module('gettext').directive('translate', function (gettextCatalog, $pars
             gettextUtil.assert(!attrs.translateN || attrs.translatePlural, 'translate-plural', 'translate-n');
 
             var msgid = gettextUtil.trim(element.html());
+            msgid = gettextCatalog.rollBackOvercorrections(element.context.innerText, msgid);
             var translatePlural = attrs.translatePlural;
             var translateContext = attrs.translateContext;
 


### PR DESCRIPTION
Keys are broken by gettext if they contain ampersands that are not html-encoded. The reason is, gettext uses .html() on keys in a few places, which html-encodes ampersands (among other special characters).

The two places in gettext that break keys with amersands are in [directive.js line #99](https://github.com/rubenv/angular-gettext/blob/20d88695a25257764a62131182be271661b7b146/src/directive.js#L99) and in [catalog.js line #174](https://github.com/rubenv/angular-gettext/blob/20d88695a25257764a62131182be271661b7b146/src/catalog.js#L174).

I've corrected this by comparing the original key to the "overcorrected" key, and where the original did not have an html-encoded ampersand, the html-encoded ampersand is replaced with an unencoded ampersand.

A new function rollBackOvercorrections is used for this correction. Tested and working in a large project with 1500 translated translations.

This PR only fixes ampersands, but other html-encodings can also be fixed with a simple addition to this code.