### PR TITLE
Fix Angularjs 1.7.0 BC angular.lowercase

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -54,7 +54,7 @@
  * ```
  */
 angular.module('gettext').directive('translate', function (gettextCatalog, $parse, $animate, $compile, $window, gettextUtil) {
-    var msie = parseInt((/msie (\d+)/.exec(angular.lowercase($window.navigator.userAgent)) || [])[1], 10);
+    var msie = parseInt((/msie (\d+)/.exec($window.navigator.userAgent.toLowerCase()) || [])[1], 10);
     var PARAMS_PREFIX = 'translateParams';
 
     function getCtxAttr(key) {


### PR DESCRIPTION
`angular.lowercase` is no longer available in angularjs 1.7.0

https://github.com/angular/angular.js/blob/master/CHANGELOG.md#angular-due-to