### PR TITLE
Replace usage of angular.lowercase with .toLowerCase()

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -54,8 +54,7 @@
  * ```
  */
 angular.module('gettext').directive('translate', function (gettextCatalog, $parse, $animate, $compile, $window, gettextUtil) {
-    var lowercase = angular.$$lowercase || angular.lowercase;
-    var msie = parseInt((/msie (\d+)/.exec(lowercase($window.navigator.userAgent)) || [])[1], 10);
+    var msie = parseInt((/msie (\d+)/i.exec($window.navigator.userAgent) || [])[1], 10);
     var PARAMS_PREFIX = 'translateParams';
 
     function getCtxAttr(key) {


### PR DESCRIPTION
> 
> Due to 1daa4f, the helper functions angular.lowercase and angular.uppercase have been removed.
> 
> These functions have been deprecated since 1.5.0. They are internally used, but should not be exposed as they contain special locale handling (for Turkish) to maintain internal consistency regardless of user-set locale.
> 
> Developers should generally use the built-ins toLowerCase and toUpperCase or toLocaleLowerCase and toLocaleUpperCase for special cases.
> 
> Further, we generally discourage using the angular.x helpers in application code.
> 
> 
> [Link to changelog](https://docs.angularjs.org/guide/migration#-angular-)
> 
> 
**Changes**:
Make the regex case insensitive and remove call to deprecated method.

**Reason to merge this PR**:
Have angular 1.7 compatibility.